### PR TITLE
chore: Upgrade tslint-immutable to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "tslint-config-prettier": "1.15.0",
-    "tslint-immutable": "4.7.0"
+    "tslint-immutable": "6.0.1"
   },
   "devDependencies": {
     "tslint": "5.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,9 +202,12 @@ tslint-config-prettier@1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
 
-tslint-immutable@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/tslint-immutable/-/tslint-immutable-4.7.0.tgz#086dfabfb5bc4c508128bc5f4e8e2d3fb1494f23"
+tslint-immutable@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tslint-immutable/-/tslint-immutable-6.0.1.tgz#6ae3f85cc3d8fb9d465d2f9a90ed6d6c50ccd3e6"
+  integrity sha512-3GQ6HffN64gLmT/N1YzyVMqyf6uBjMvhNaevK8B0K01/QC0OU5AQZrH4TjMHo1IdG3JpqsZvuRy9IW1LA3zjwA==
+  dependencies:
+    tsutils "^2.28.0 || ^3.0.0"
 
 tslint@5.11.0:
   version "5.11.0"
@@ -226,6 +229,13 @@ tslint@5.11.0:
 tsutils@^2.27.2:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
+  dependencies:
+    tslib "^1.8.1"
+
+"tsutils@^2.28.0 || ^3.0.0":
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
This PR upgrades `tslint-immutable` to the latest version, so I can finally use `readonly Foo[]` instead of `ReadonlyArray<Foo>` :blush: 

https://github.com/jonaskello/tslint-immutable/blob/master/CHANGELOG.md#v550---2019-03-21
